### PR TITLE
Update axios peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "http"
     ],
     "peerDependencies": {
-        "axios": "^0.18.0"
+        "axios": ">= 0.18.0"
     },
     "devDependencies": {
         "axios": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "http"
     ],
     "peerDependencies": {
-        "axios": "^0.17.1"
+        "axios": "^0.18.0"
     },
     "devDependencies": {
         "axios": "^0.18.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "http"
     ],
     "peerDependencies": {
-        "axios": ">= 0.18.0"
+        "axios": ">= 0.17.1"
     },
     "devDependencies": {
         "axios": "^0.18.0",


### PR DESCRIPTION
Hello @emileber!

Axios devDependency is not the same as peerDependency, and we need to update it.
